### PR TITLE
Feature/charts 3248 embedded charts jwt demo

### DIFF
--- a/embedding-sdk/authenticated/jwt/app.js
+++ b/embedding-sdk/authenticated/jwt/app.js
@@ -14,7 +14,6 @@ app.use(cors());
 
 app.post("/login", (req, res) => {
   const loginDetails = req.body;
-  console.log(loginDetails);
   // mock a check against the database
   let mockedUsername = "admin";
   let mockedPassword = "password";

--- a/embedding-sdk/authenticated/jwt/app.js
+++ b/embedding-sdk/authenticated/jwt/app.js
@@ -1,0 +1,36 @@
+const express = require("express");
+const bodyParser = require("body-parser");
+const cors = require("cors");
+const jwt = require("jsonwebtoken");
+const config = require("./config.js");
+
+const app = express();
+const port = 8000;
+
+// Configuring body parser middleware
+app.use(bodyParser.urlencoded({ extended: false }));
+app.use(bodyParser.json());
+app.use(cors());
+
+app.post("/login", (req, res) => {
+  const loginDetails = req.body;
+  console.log(loginDetails);
+  // mock a check against the database
+  let mockedUsername = "admin";
+  let mockedPassword = "password";
+
+  if (
+    loginDetails &&
+    loginDetails.username === mockedUsername &&
+    loginDetails.password === mockedPassword
+  ) {
+    let token = jwt.sign({ username: loginDetails.username }, config.secret, {
+      expiresIn: "24h" // expires in 24 hours
+    });
+    res.json({ bearerToken: token });
+  } else {
+    res.status(401).send(false);
+  }
+});
+
+app.listen(port, () => console.log(`Example app listening on port ${port}!`));

--- a/embedding-sdk/authenticated/jwt/assets/styles.css
+++ b/embedding-sdk/authenticated/jwt/assets/styles.css
@@ -14,6 +14,24 @@
   text-align: center;
 }
 
+body.logged-in #login-page {
+  visibility: hidden;
+  height: 0;
+  width: 0;
+}
+
+body.logged-in #lock::before {
+  content: "🔐";
+}
+
+body #lock::before {
+  content: "🔒";
+}
+
+body.logged-in #chart {
+  visibility: visible;
+}
+
 .hideLogin {
   visibility: hidden;
   height: 0;

--- a/embedding-sdk/authenticated/jwt/assets/styles.css
+++ b/embedding-sdk/authenticated/jwt/assets/styles.css
@@ -1,0 +1,95 @@
+#chart {
+  border-top: none;
+  background-color: #f9fbfa;
+  flex-grow: 1;
+  height: 100%;
+  box-shadow: grey 0px 0px 10px 1px;
+  visibility: hidden;
+}
+
+.chart-container {
+  height: 30vw;
+  width: 80vh;
+  margin: auto;
+  text-align: center;
+}
+
+.hideLogin {
+  visibility: hidden;
+  height: 0;
+  width: 0;
+}
+
+.main {
+  box-sizing: border-box;
+  padding: 1rem;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+.login-page {
+  width: 360px;
+  margin: auto;
+}
+.form {
+  position: relative;
+  z-index: 1;
+  background: #ffffff;
+  max-width: 360px;
+  margin: 0 auto 100px;
+  padding: 45px;
+  text-align: center;
+  box-shadow: 0 0 20px 0 rgba(0, 0, 0, 0.2), 0 5px 5px 0 rgba(0, 0, 0, 0.24);
+}
+.form input {
+  font-family: "Heebo", sans-serif;
+  outline: 0;
+  background: #f2f2f2;
+  width: 100%;
+  border: 0;
+  margin: 0 0 15px;
+  padding: 15px;
+  box-sizing: border-box;
+  font-size: 14px;
+}
+.form button {
+  font-family: "Heebo", sans-serif;
+  text-transform: uppercase;
+  outline: 0;
+  background: #13aa52;
+  width: 100%;
+  border: 0;
+  padding: 15px;
+  color: #ffffff;
+  font-size: 14px;
+  -webkit-transition: all 0.3 ease;
+  transition: all 0.3 ease;
+  cursor: pointer;
+}
+.form button:hover,
+.form button:active,
+.form button:focus {
+  background: #109246;
+}
+.form .message {
+  margin: 15px 0 0;
+  color: #b3b3b3;
+  font-size: 12px;
+}
+.form .message a {
+  color: #13aa52;
+  text-decoration: none;
+}
+
+body {
+  background: #e7eeec; /* fallback for old browsers */
+  font-family: "Heebo", sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  text-align: center;
+}
+
+h1 {
+  padding: 8% 0 0;
+}

--- a/embedding-sdk/authenticated/jwt/config.js
+++ b/embedding-sdk/authenticated/jwt/config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  secret: "pineapple"
+  secret: "topsecret"
 };

--- a/embedding-sdk/authenticated/jwt/config.js
+++ b/embedding-sdk/authenticated/jwt/config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  secret: "pineapple"
+};

--- a/embedding-sdk/authenticated/jwt/index.html
+++ b/embedding-sdk/authenticated/jwt/index.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Charts Embedded SDK Demo</title>
+    <meta charset="UTF-8" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdnjs.cloudflare.com/ajax/libs/normalize/8.0.1/normalize.min.css"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Heebo&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" type="text/css" href="assets/styles.css" />
+  </head>
+
+  <body>
+    <main>
+      <h1 id="lock">🔒</h1>
+      <div id="login-page" class="login-page">
+        <div class="form">
+          <div class="login-form">
+            <h1>Secure Chart Viewer</h1>
+            <input id="username" type="text" placeholder="name" />
+            <input type="password" id="password" placeholder="password" />
+            <button id="loginButton">Log In</button>
+            <p class="message">Username: admin Password: password</p>
+          </div>
+        </div>
+      </div>
+      <div class="chart-container">
+        <div id="chart"></div>
+      </div>
+    </main>
+    <script src="src/index.js"></script>
+  </body>
+</html>

--- a/embedding-sdk/authenticated/jwt/index.html
+++ b/embedding-sdk/authenticated/jwt/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>Charts Embedded SDK Demo</title>
+    <title>Charts Embedded SDK - Authenticated Embedded Chart Demo</title>
     <meta charset="UTF-8" />
     <link
       rel="stylesheet"
@@ -17,7 +17,7 @@
 
   <body>
     <main>
-      <h1 id="lock">🔒</h1>
+      <h1 id="lock"></h1>
       <div id="login-page" class="login-page">
         <div class="form">
           <div class="login-form">

--- a/embedding-sdk/authenticated/jwt/package.json
+++ b/embedding-sdk/authenticated/jwt/package.json
@@ -8,9 +8,12 @@
     "build": "parcel build index.html"
   },
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "1.0.0-beta.1",
+    "@mongodb-js/charts-embed-dom": "^1.0.0-beta.2",
+    "cors": "^2.8.5",
     "express": "^4.16.3",
-    "jsonwebtoken": "^8.3.0"
+    "jsonwebtoken": "^8.3.0",
+    "regenerator-runtime": "^0.13.3",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",

--- a/embedding-sdk/authenticated/jwt/package.json
+++ b/embedding-sdk/authenticated/jwt/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.html",
   "scripts": {
-    "start": "parcel index.html --open",
+    "start": "node app.js & parcel index.html --open",
     "build": "parcel build index.html"
   },
   "dependencies": {

--- a/embedding-sdk/authenticated/jwt/package.json
+++ b/embedding-sdk/authenticated/jwt/package.json
@@ -2,18 +2,19 @@
   "name": "mongodb-charts-embedded-sdk-authenticated-demo",
   "version": "1.0.0",
   "description": "",
-  "main": "server.js",
+  "main": "index.html",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "start": "parcel index.html --open",
+    "build": "parcel build index.html"
   },
-  "license": "ISC",
   "dependencies": {
-    "@mongodb-js/charts-embed-dom": "^0.0.0-dev.9",
+    "@mongodb-js/charts-embed-dom": "1.0.0-beta.1",
     "express": "^4.16.3",
     "jsonwebtoken": "^8.3.0"
   },
   "devDependencies": {
     "@babel/core": "^7.8.6",
-    "@babel/preset-env": "^7.8.6"
+    "@babel/preset-env": "^7.8.6",
+    "parcel-bundler": "^1.6.1"
   }
 }

--- a/embedding-sdk/authenticated/jwt/package.json
+++ b/embedding-sdk/authenticated/jwt/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mongodb-charts-embedded-sdk-authenticated-demo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "license": "ISC",
+  "dependencies": {
+    "@mongodb-js/charts-embed-dom": "^0.0.0-dev.9",
+    "express": "^4.16.3",
+    "jsonwebtoken": "^8.3.0"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.8.6",
+    "@babel/preset-env": "^7.8.6"
+  }
+}

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -14,17 +14,9 @@ This sample shows how to use the JavaScript Embedding SDK to render **authentica
 
 #### The features included in this demo are as follows:
 
-- Render an embedded chart on a web page
-- Set the charts theme to either `'light'` or `'dark'`
-- Get the charts current theme
-- Set the charts refresh interval
-  - Note, the default interval is 0, implying that after rendering, the chart will never refresh.
-  - The minimum refresh interval is 10 seconds.
-- Get the charts current refresh interval
-- Manually refresh the chart
-- Set the charts current filter
-  - Note, filtering on a chart requires setting up white listed fields in MongoDB Charts. We have done this for our sample data.
-- Get the current filter on a chart
+- 📈 Render an embedded chart on a web page
+- 🔒 Only render charts to valid users
+- 🔑 Custom JWT authentication via `jsonwebtoken`
 
 ## Preparing your Chart for Embedding
 
@@ -34,21 +26,25 @@ This sample is preconfigured to render a specific chart. You can run the sample 
 
 2. If you haven't done so already, create a chart on any dashboard that you would like to embed.
 
-3. Go to the Data Sources tab, find the data source that you are using on the chart, and choose Embedding Options from the ... menu. Make sure that embedding is enabled for this data source and select '**Unauthenticated or Verified Signature**'
+3. Go to the Data Sources tab, find the data source that you are using on the chart, and choose External Sharing Options from the ... menu. Make sure that embedding is enabled for this data source and select '**Verified Signature Only**'
 
 4. Find the chart you want to embed, click the **...** menu and select **Embed Chart**
 
-5. Ensure the Unauthenticated tab is selected and turn on '**Enable unauthenticated access**'
+5. Ensure the Unauthenticated tab is selected and turn on '**Enable authenticated access**'
 
-6. Select the **Javascript SDK** option
+6. Note the Chart ID and the Chart Base URL, as you will need them for running the demo.
 
-7. Note the Chart ID and the Chart Base URL, as you will need them for running the demo.
+7. Close the menu and click on the Admin Settings button.
 
-8. **Optional**
-   In the same menu, note the **User Specified Filters** option. If you wish to try out filtering on your own dataset, you will need to whitelist a field by which to filter on. For example, our sample AirBnB dataset filters on `address.country`.
-   Furthermore, the filter related code in `src/index.js` will need to be updated to conform to the filter query you wish to run, and the options provided in `index.html` will need to be updated too. To be clear,
-   - Update the query **field** in `src/index.js`
-   - Update the query **values** in `index.html`
+8. Under Embedding Authentication Providers, press the **Add New Provider** button
+9. Fill in the details like so:
+
+![](https://i.imgur.com/8cS1iSJ.png)
+
+- Name: `Custom JWT` _Note, this is only for your convenience and can be named anything_
+- Provider: `Custom JSON Web Token`
+- Signing Algorithm: `HS256` _Note, this is the default signing algorithm for the `jsonwebtoken` library and many others_
+- Signing Key: `topsecret` _Note, this key must correlate with the key found in `config.js`_
 
 ## Running this Sample
 
@@ -63,7 +59,7 @@ _The following steps presume the use of npm, though yarn works as well._
    - Open the _index.js_ file (`src/index.js`)
    - Replace the `baseUrl` string on with the base URL you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
    - Replace the `chartId` string on with the chart ID you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
-   - Replace `address.country` in the `setFilter` code with your whitelisted field (look for "\~REPLACE\~" in the comments)
+   - Replace the second `chartId`string with the same ID. (look for "\~REPLACE\~" in the comments)
 4. Run `npm install` to install the package dependencies.
 5. Run `npm install -g parcel-bundler` to install Parcel. You may need to run `sudo npm install -g parcel-bundler` if you lack permissions.
    - Optional Parcel.js documentation https://parceljs.org/ for more information on what this is
@@ -76,7 +72,7 @@ This should create a local server running the Charts demo. Open a web browser an
 Once you gain an understanding of the API, consider the following
 
 - Take on the optional steps to prepare and manipulate your own data source rather than the sample.
-- Think whether an unauthenticated chart is the feature you're after. Embedding iframes from Charts is a great way to showcase your data if you don't need the user to interact with the chart.
-- Consider the data you're making available, and the queries you're allowing. If the data is sensitive and you need to ensure the charts can only be accessed by authorized people, you should look at using authenticated embedding.
+- Change the login logic to adapt to your project's security workflow.
+- Think whether an authenticated chart is the feature you're after. If you're simply looking for a way to show off your data, unauthenticated embedding simplifies the workflow even further.
 
 Happy Charting! 🚀📈

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -10,7 +10,7 @@ MongoDB Charts allows you to create visualizations of your MongoDB data using a 
 
 Charts can be embedded either using a simple IFRAME snippet, or by using the Charts Embedding SDK from your JavaScript code. When using the SDK, embedded charts can be either unauthenticated (meaning anyone who has the embed code can view the chart), or authenticated (whereby the user can only view the chart if they have an active authentication session linked to a Charts authentication provider).
 
-The sample app has its own authentication and token issuing logic. You may want to follow a similar approach if you are not integrating with an external authentication mechanism or your authentication is not based on JWTs. Alternatively, if you are using an existing authentication mechanism that issues JWTs, you can use those tokens to authenticate your chart rendering requests after configuring a Charts authentication provider that can validate the JWT.
+This sample shows how to use the JavaScript Embedding SDK to render **authenticated** embedded charts, specifically via a custom jwt authentication. The sample app has its own authentication and token issuing logic. You may want to follow a similar approach if you are not integrating with an external authentication mechanism or your authentication is not based on JWTs. Alternatively, if you are using an existing authentication mechanism that issues JWTs, you can use those tokens to authenticate your chart rendering requests after configuring a Charts authentication provider that can validate the JWT.
 
 #### The features included in this demo are as follows:
 

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -10,7 +10,7 @@ MongoDB Charts allows you to create visualizations of your MongoDB data using a 
 
 Charts can be embedded either using a simple IFRAME snippet, or by using the Charts Embedding SDK from your JavaScript code. When using the SDK, embedded charts can be either unauthenticated (meaning anyone who has the embed code can view the chart), or authenticated (whereby the user can only view the chart if they have an active authentication session linked to a Charts authentication provider).
 
-This sample shows how to use the JavaScript Embedding SDK to render **authenticated** embedded charts, specifically via a custom jwt authentication.
+The sample app has its own authentication and token issuing logic. You may want to follow a similar approach if you are not integrating with an external authentication mechanism or your authentication is not based on JWTs. Alternatively, if you are using an existing authentication mechanism that issues JWTs, you can use those tokens to authenticate your chart rendering requests after configuring a Charts authentication provider that can validate the JWT.
 
 #### The features included in this demo are as follows:
 

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -4,7 +4,7 @@
 
 📄 _[See the MongoDB Charts Embedding Docs for more details](https://docs.mongodb.com/charts/saas/embedding-charts/)_
 
-🎮 _[Play with a live demo of this sample here]()_
+🎮 _[Play with a live demo of this sample here](https://codesandbox.io/s/github/mongodb/charts-embedding-examples/tree/feature/CHARTS-3248-embedded-charts-jwt-demo/embedding-sdk/authenticated/jwt)_
 
 MongoDB Charts allows you to create visualizations of your MongoDB data using a simple web interface. You can view the visualizations within the Charts UI, or you can use the Embedding feature to render the charts in an external web application.
 

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -64,6 +64,7 @@ _The following steps presume the use of npm, though yarn works as well._
 5. Run `npm install -g parcel-bundler` to install Parcel. You may need to run `sudo npm install -g parcel-bundler` if you lack permissions.
    - Optional Parcel.js documentation https://parceljs.org/ for more information on what this is
 6. Run `parcel index.html` to launch the sample application
+7. Run `node app.js`to launch the sample jwt server
 
 This should create a local server running the Charts demo. Open a web browser and navigate to `http://localhost:1234` in the url bar to see the sample.
 

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -63,10 +63,13 @@ _The following steps presume the use of npm, though yarn works as well._
 4. Run `npm install` to install the package dependencies.
 5. Run `npm install -g parcel-bundler` to install Parcel. You may need to run `sudo npm install -g parcel-bundler` if you lack permissions.
    - Optional Parcel.js documentation https://parceljs.org/ for more information on what this is
-6. Run `parcel index.html` to launch the sample application
-7. Run `node app.js`to launch the sample jwt server
+6. Run `npm start` to start the application.
 
-This should create a local server running the Charts demo. Open a web browser and navigate to `http://localhost:1234` in the url bar to see the sample.
+This should create a local server running the Charts demo. Open a web browser and navigate to `http://localhost:1234` in the url bar to see the sample. Along with this, a local jwt authentication server will be spun up on `http://localhost:8000`.
+
+The hard coded credentials used in this demo are:
+username : `admin`
+password: `password`
 
 ## Next Steps
 

--- a/embedding-sdk/authenticated/jwt/readme.md
+++ b/embedding-sdk/authenticated/jwt/readme.md
@@ -1,0 +1,82 @@
+# MongoDB Charts Embedding Example - Authenticated Embedded Chart
+
+## Background
+
+📄 _[See the MongoDB Charts Embedding Docs for more details](https://docs.mongodb.com/charts/saas/embedding-charts/)_
+
+🎮 _[Play with a live demo of this sample here]()_
+
+MongoDB Charts allows you to create visualizations of your MongoDB data using a simple web interface. You can view the visualizations within the Charts UI, or you can use the Embedding feature to render the charts in an external web application.
+
+Charts can be embedded either using a simple IFRAME snippet, or by using the Charts Embedding SDK from your JavaScript code. When using the SDK, embedded charts can be either unauthenticated (meaning anyone who has the embed code can view the chart), or authenticated (whereby the user can only view the chart if they have an active authentication session linked to a Charts authentication provider).
+
+This sample shows how to use the JavaScript Embedding SDK to render **authenticated** embedded charts, specifically via a custom jwt authentication.
+
+#### The features included in this demo are as follows:
+
+- Render an embedded chart on a web page
+- Set the charts theme to either `'light'` or `'dark'`
+- Get the charts current theme
+- Set the charts refresh interval
+  - Note, the default interval is 0, implying that after rendering, the chart will never refresh.
+  - The minimum refresh interval is 10 seconds.
+- Get the charts current refresh interval
+- Manually refresh the chart
+- Set the charts current filter
+  - Note, filtering on a chart requires setting up white listed fields in MongoDB Charts. We have done this for our sample data.
+- Get the current filter on a chart
+
+## Preparing your Chart for Embedding
+
+This sample is preconfigured to render a specific chart. You can run the sample as-is, or you can modify it to render your own chart by completing the following steps:
+
+1. Log onto MongoDB Charts
+
+2. If you haven't done so already, create a chart on any dashboard that you would like to embed.
+
+3. Go to the Data Sources tab, find the data source that you are using on the chart, and choose Embedding Options from the ... menu. Make sure that embedding is enabled for this data source and select '**Unauthenticated or Verified Signature**'
+
+4. Find the chart you want to embed, click the **...** menu and select **Embed Chart**
+
+5. Ensure the Unauthenticated tab is selected and turn on '**Enable unauthenticated access**'
+
+6. Select the **Javascript SDK** option
+
+7. Note the Chart ID and the Chart Base URL, as you will need them for running the demo.
+
+8. **Optional**
+   In the same menu, note the **User Specified Filters** option. If you wish to try out filtering on your own dataset, you will need to whitelist a field by which to filter on. For example, our sample AirBnB dataset filters on `address.country`.
+   Furthermore, the filter related code in `src/index.js` will need to be updated to conform to the filter query you wish to run, and the options provided in `index.html` will need to be updated too. To be clear,
+   - Update the query **field** in `src/index.js`
+   - Update the query **values** in `index.html`
+
+## Running this Sample
+
+_The following steps presume the use of npm, though yarn works as well._
+
+1. Ensure you have Node installed. You can confirm with `node --version`. On some operating systems, Node available as the `nodejs` binary instead.
+
+2. Clone the Git repository or download the code to your computer.
+
+3. **Optional**
+   If you do not wish to use our sample data and have completed the above steps to prepare your own chart for embedding,
+   - Open the _index.js_ file (`src/index.js`)
+   - Replace the `baseUrl` string on with the base URL you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
+   - Replace the `chartId` string on with the chart ID you copied from the MongoDB Charts Embedded Chart menu (look for "\~REPLACE\~" in the comments)
+   - Replace `address.country` in the `setFilter` code with your whitelisted field (look for "\~REPLACE\~" in the comments)
+4. Run `npm install` to install the package dependencies.
+5. Run `npm install -g parcel-bundler` to install Parcel. You may need to run `sudo npm install -g parcel-bundler` if you lack permissions.
+   - Optional Parcel.js documentation https://parceljs.org/ for more information on what this is
+6. Run `parcel index.html` to launch the sample application
+
+This should create a local server running the Charts demo. Open a web browser and navigate to `http://localhost:1234` in the url bar to see the sample.
+
+## Next Steps
+
+Once you gain an understanding of the API, consider the following
+
+- Take on the optional steps to prepare and manipulate your own data source rather than the sample.
+- Think whether an unauthenticated chart is the feature you're after. Embedding iframes from Charts is a great way to showcase your data if you don't need the user to interact with the chart.
+- Consider the data you're making available, and the queries you're allowing. If the data is sensitive and you need to ensure the charts can only be accessed by authorized people, you should look at using authenticated embedding.
+
+Happy Charting! 🚀📈

--- a/embedding-sdk/authenticated/jwt/src/index.js
+++ b/embedding-sdk/authenticated/jwt/src/index.js
@@ -1,7 +1,5 @@
 import ChartsEmbedSDK from "@mongodb-js/charts-embed-dom";
 import "regenerator-runtime/runtime";
-import jwt from "jsonwebtoken";
-import config from "../config";
 
 document
   .getElementById("loginButton")
@@ -16,7 +14,7 @@ function getPass() {
 }
 
 async function tryLogin() {
-  if (login(getUser(), getPass())) {
+  if (await login(getUser(), getPass())) {
     document.body.classList.toggle("logged-in", true);
     await renderChart();
   }
@@ -29,21 +27,18 @@ async function tryLogin() {
   which creates the token using the users username and our previously
   defined secret called 'topsecret'.
 */
-function login(username, password) {
-  // mock a check against the database
-  let mockedUsername = "admin";
-  let mockedPassword = "password";
+async function login(username, password) {
+  const rawResponse = await fetch("http://localhost:8000/login", {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify({ username: username, password: password })
+  });
+  const content = await rawResponse.json();
 
-  if (username && password) {
-    if (username === mockedUsername && password === mockedPassword) {
-      let token = jwt.sign({ username: username }, config.secret, {
-        expiresIn: "24h" // expires in 24 hours
-      });
-      return token;
-    }
-  } else {
-    return false;
-  }
+  return content.bearerToken;
 }
 
 /*

--- a/embedding-sdk/authenticated/jwt/src/index.js
+++ b/embedding-sdk/authenticated/jwt/src/index.js
@@ -52,8 +52,8 @@ async function renderChart() {
   const sdk = new ChartsEmbedSDK({
     baseUrl: "https://localhost/mongodb-charts-iwfxn", // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
     chartId: "d98f67cf-374b-4823-a2a8-f86e9d480065", // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
-    getUserToken: function() {
-      login(getUser(), getPass());
+    getUserToken: async function() {
+      return await login(getUser(), getPass());
     }
   });
 

--- a/embedding-sdk/authenticated/jwt/src/index.js
+++ b/embedding-sdk/authenticated/jwt/src/index.js
@@ -7,24 +7,28 @@ document
   .getElementById("loginButton")
   .addEventListener("click", async () => await tryLogin());
 
-function user() {
+function getUser() {
   return document.getElementById("username").value;
 }
 
-function pass() {
+function getPass() {
   return document.getElementById("password").value;
 }
 
 async function tryLogin() {
-  if (login(user(), pass())) {
-    document.getElementById("login-page").className = "hideLogin";
-    document.getElementById("chart").style.visibility = "visible";
-    document.getElementById("lock").innerText = "🔓";
+  if (login(getUser(), getPass())) {
+    document.body.classList.toggle("logged-in", true);
     await renderChart();
-    //await renderUnauthenticatedChart();
   }
 }
 
+/*
+  login(username, password) is the function we are going to give to the
+  SDK to authenticate the user. It can be any function that returns a 
+  JWT token on success. The core of this function is the jwt.sign code,
+  which creates the token using the users username and our previously
+  defined secret called 'topsecret'.
+*/
 function login(username, password) {
   // mock a check against the database
   let mockedUsername = "admin";
@@ -42,16 +46,23 @@ function login(username, password) {
   }
 }
 
+/*
+  Chart rendering is much the same as our unauthenticated charts. However,
+  we now need to give the SDK a value for 'getUserToken'. This value needs
+  to be a function that returns a valid JWT. We are using an anonymous 
+  function syntax in order to pass variables to the function that
+  will be called at a later time by the SDK code.
+ */
 async function renderChart() {
   const sdk = new ChartsEmbedSDK({
-    baseUrl: "https://localhost/mongodb-charts-iwfxn",
-    chartId: "d98f67cf-374b-4823-a2a8-f86e9d480065",
+    baseUrl: "https://localhost/mongodb-charts-iwfxn", // Optional: ~REPLACE~ with the Base URL from your Embed Chart dialog
+    chartId: "d98f67cf-374b-4823-a2a8-f86e9d480065", // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
     getUserToken: function() {
-      login(user(), pass());
+      login(getUser(), getPass());
     }
   });
 
-  const chart = sdk.createChart({ id: "d98f67cf-374b-4823-a2a8-f86e9d480065" });
+  const chart = sdk.createChart({ id: "d98f67cf-374b-4823-a2a8-f86e9d480065" }); // Optional: ~REPLACE~ with the Chart ID from your Embed Chart dialog
 
   // render the chart into a container
   chart.render(document.getElementById("chart"));

--- a/embedding-sdk/authenticated/jwt/src/index.js
+++ b/embedding-sdk/authenticated/jwt/src/index.js
@@ -1,0 +1,58 @@
+import ChartsEmbedSDK from "@mongodb-js/charts-embed-dom";
+import "regenerator-runtime/runtime";
+import jwt from "jsonwebtoken";
+import config from "../config";
+
+document
+  .getElementById("loginButton")
+  .addEventListener("click", async () => await tryLogin());
+
+function user() {
+  return document.getElementById("username").value;
+}
+
+function pass() {
+  return document.getElementById("password").value;
+}
+
+async function tryLogin() {
+  if (login(user(), pass())) {
+    document.getElementById("login-page").className = "hideLogin";
+    document.getElementById("chart").style.visibility = "visible";
+    document.getElementById("lock").innerText = "🔓";
+    await renderChart();
+    //await renderUnauthenticatedChart();
+  }
+}
+
+function login(username, password) {
+  // mock a check against the database
+  let mockedUsername = "admin";
+  let mockedPassword = "password";
+
+  if (username && password) {
+    if (username === mockedUsername && password === mockedPassword) {
+      let token = jwt.sign({ username: username }, config.secret, {
+        expiresIn: "24h" // expires in 24 hours
+      });
+      return token;
+    }
+  } else {
+    return false;
+  }
+}
+
+async function renderChart() {
+  const sdk = new ChartsEmbedSDK({
+    baseUrl: "https://localhost/mongodb-charts-iwfxn",
+    chartId: "d98f67cf-374b-4823-a2a8-f86e9d480065",
+    getUserToken: function() {
+      login(user(), pass());
+    }
+  });
+
+  const chart = sdk.createChart({ id: "d98f67cf-374b-4823-a2a8-f86e9d480065" });
+
+  // render the chart into a container
+  chart.render(document.getElementById("chart"));
+}


### PR DESCRIPTION
## JIRA ticket link

Task: 📈 [CHARTS-3248](https://jira.mongodb.org/browse/CHARTS-3248)

## Description

A new demo for authenticated embedding. Shows off Custom JWT Provider settings in action. A simple login (username: admin, password: password) kicks off a JWT signing process, and said function is passed along to the SDK where the magic happens. 

### Featues

- 📈 Render an embedded chart on a web page
- 🔒 Only render charts to valid users
- 🔑 Custom JWT authentication via `jsonwebtoken`


## Screencast
![Screen Shot 2020-03-04 at 1 18 25 pm](https://user-images.githubusercontent.com/19422770/75838671-a8a88b00-5e1a-11ea-93ab-41204756f3ca.png)
